### PR TITLE
[#4] No interrupt support during processing state

### DIFF
--- a/lib/providers/conversation_provider.dart
+++ b/lib/providers/conversation_provider.dart
@@ -23,6 +23,7 @@ class ConversationProvider extends ChangeNotifier {
   LLMService? _llmService;
   TtsService _ttsService;
   Settings _settings = const Settings();
+  StreamSubscription<String>? _llmSubscription;
 
   ConversationState _state = ConversationState.idle;
   List<Message> _messages = [];
@@ -92,11 +93,9 @@ class ConversationProvider extends ChangeNotifier {
         _startListening();
       case ConversationState.listening:
         _stopListeningAndProcess();
+      case ConversationState.processing:
       case ConversationState.speaking:
         _interrupt();
-      case ConversationState.processing:
-        // Do nothing while processing
-        break;
     }
   }
 
@@ -219,34 +218,46 @@ class ConversationProvider extends ChangeNotifier {
       );
 
       bool firstChunk = true;
-      await for (final delta in stream) {
-        _streamingText += delta;
-        _textBuffer += delta;
+      final completer = Completer<void>();
+      _llmSubscription = stream.listen(
+        (delta) {
+          _streamingText += delta;
+          _textBuffer += delta;
 
-        // Update assistant message in place
-        _updateLastMessage(_streamingText, isComplete: false);
+          // Update assistant message in place
+          _updateLastMessage(_streamingText, isComplete: false);
 
-        if (firstChunk) {
-          _setState(ConversationState.speaking);
-          firstChunk = false;
-        } else {
+          if (firstChunk) {
+            _setState(ConversationState.speaking);
+            firstChunk = false;
+          } else {
+            notifyListeners();
+          }
+
+          // Extract complete sentences and send to TTS
+          _flushSentences();
+        },
+        onDone: () {
+          // Flush remaining buffer to TTS
+          if (_textBuffer.trim().isNotEmpty) {
+            _ttsService.enqueue(_textBuffer.trim());
+            _textBuffer = '';
+          }
+          _ttsService.markFinished();
+
+          // Mark message complete
+          _updateLastMessage(_streamingText, isComplete: true);
           notifyListeners();
-        }
 
-        // Extract complete sentences and send to TTS
-        _flushSentences();
-      }
+          completer.complete();
+        },
+        onError: (e) {
+          completer.completeError(e);
+        },
+        cancelOnError: true,
+      );
 
-      // Flush remaining buffer to TTS
-      if (_textBuffer.trim().isNotEmpty) {
-        _ttsService.enqueue(_textBuffer.trim());
-        _textBuffer = '';
-      }
-      _ttsService.markFinished();
-
-      // Mark message complete
-      _updateLastMessage(_streamingText, isComplete: true);
-      notifyListeners();
+      await completer.future;
 
       // Wait for TTS to finish
       await _ttsService.waitUntilDone();
@@ -265,6 +276,7 @@ class ConversationProvider extends ChangeNotifier {
       }
     }
 
+    _llmSubscription = null;
     _setState(ConversationState.idle);
   }
 
@@ -293,6 +305,8 @@ class ConversationProvider extends ChangeNotifier {
   }
 
   void _interrupt() {
+    _llmSubscription?.cancel();
+    _llmSubscription = null;
     _ttsService.stop();
     _speechService.cancelListening();
     _setState(ConversationState.idle);
@@ -401,6 +415,7 @@ class ConversationProvider extends ChangeNotifier {
 
   @override
   void dispose() {
+    _llmSubscription?.cancel();
     _speechService.dispose();
     unawaited(_ttsService.dispose());
     _llmService?.dispose();

--- a/test/unit/providers/conversation_provider_test.dart
+++ b/test/unit/providers/conversation_provider_test.dart
@@ -150,6 +150,32 @@ void main() {
       verify(mockSpeechService.cancelListening()).called(1);
     });
 
+    test('interrupts when toggleConversation called during processing state',
+        () async {
+      final mockTts = MockTtsService();
+      when(mockTts.stop()).thenAnswer((_) async {});
+      when(mockTts.dispose()).thenAnswer((_) async {});
+
+      // Do NOT call initialize() — it replaces _ttsService via _rebuildTtsService.
+      // Injecting ttsService in the constructor is enough for this unit test.
+      final processingProvider = ConversationProvider(
+        speechService: mockSpeechService,
+        settingsService: mockSettingsService,
+        ttsService: mockTts,
+      );
+
+      // Force into processing state via the @visibleForTesting helper
+      processingProvider.forceStateForTesting(ConversationState.processing);
+      expect(processingProvider.state, ConversationState.processing);
+
+      // toggleConversation in processing state should call _interrupt → idle
+      processingProvider.toggleConversation();
+
+      expect(processingProvider.state, ConversationState.idle);
+      verify(mockTts.stop()).called(1);
+      verify(mockSpeechService.cancelListening()).called(1);
+    });
+
     test('partial STT text is updated during listening', () async {
       await provider.initialize();
 


### PR DESCRIPTION
Closes #4

## What changed

- Added `StreamSubscription<String>? _llmSubscription` field to track the active LLM stream
- Updated `toggleConversation()` to call `_interrupt()` for both `processing` and `speaking` states
- Modified `_interrupt()` to cancel the LLM subscription before stopping TTS and speech services
- Converted stream consumption from `await for` to `.listen()` to enable cancellation
- Added cleanup in `dispose()` to cancel any active subscription

## Why

Previously, tapping the mic button during the `processing` state did nothing, leaving users stuck until the LLM response started streaming and moved to the `speaking` state. There was no way to cancel an in-flight LLM stream.

## How to test

1. Start a conversation and speak a prompt
2. While the app is in `processing` state (waiting for LLM response), tap the mic button
3. Verify the app returns to `idle` state immediately
4. Verify no errors occur and the app remains responsive

## Checklist

- ✅ `flutter analyze` — zero issues
- ✅ `flutter test` — all 180 tests pass
- ✅ Regression test added for interrupt-during-processing behaviour