### PR TITLE
[#46] Re-add OpenClaw agent discovery in settings

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -609,8 +609,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
   }
 
   Future<void> _discoverAgents() async {
-    final server =
-        widget.servers.firstWhereOrNull((s) => s.id == _selectedServerId);
+    final server = _servers.firstWhereOrNull((s) => s.id == _selectedServerId);
     if (server == null) return;
     setState(() {
       _isDiscovering = true;
@@ -641,7 +640,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
       if (!mounted) return;
       setState(() {
         _isDiscovering = false;
-        _discoveryError = 'Could not connect to server. Check URL and token.';
+        _discoveryError = 'Failed to discover agents: $e';
       });
     }
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -612,6 +612,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
     });
     try {
       final agents = await _openClawService.fetchAgents(server);
+      if (!mounted) return;
       if (agents.isEmpty) {
         setState(() {
           _isDiscovering = false;
@@ -632,6 +633,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
         }
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() {
         _isDiscovering = false;
         _discoveryError = 'Could not connect to server. Check URL and token.';

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -16,6 +16,24 @@ class SettingsScreen extends StatefulWidget {
 
   @override
   State<SettingsScreen> createState() => _SettingsScreenState();
+
+  /// Exposed for testing only. Creates an _AgentFormDialog with optional
+  /// [openClawService] mock.
+  static Widget buildAgentFormDialogForTesting({
+    required AgentType agentType,
+    AgentConfig? agent,
+    required List<VoiceConfig> voices,
+    required List<OpenClawServer> servers,
+    OpenClawService? openClawService,
+  }) {
+    return _AgentFormDialog(
+      agentType: agentType,
+      agent: agent,
+      voices: voices,
+      servers: servers,
+      openClawService: openClawService,
+    );
+  }
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
@@ -519,12 +537,14 @@ class _AgentFormDialog extends StatefulWidget {
   final AgentConfig? agent;
   final List<VoiceConfig> voices;
   final List<OpenClawServer> servers;
+  final OpenClawService? openClawService;
 
   const _AgentFormDialog({
     required this.agentType,
     this.agent,
     required this.voices,
     required this.servers,
+    this.openClawService,
   });
 
   @override
@@ -545,7 +565,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
   OpenClawServer? _newServer;
 
   // OpenClaw agent discovery state
-  final _openClawService = OpenClawService();
+  late final OpenClawService _openClawService;
   List<String>? _discoveredAgents;
   bool _isDiscovering = false;
   String? _discoveryError;
@@ -554,6 +574,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
   @override
   void initState() {
     super.initState();
+    _openClawService = widget.openClawService ?? OpenClawService();
     _nameController = TextEditingController(text: widget.agent?.name ?? '');
     _apiKeyController = TextEditingController(text: widget.agent?.apiKey ?? '');
     _modelController =
@@ -591,6 +612,14 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
     });
     try {
       final agents = await _openClawService.fetchAgents(server);
+      if (agents.isEmpty) {
+        setState(() {
+          _isDiscovering = false;
+          _discoveryError =
+              'No agents found on this server. Check your server configuration.';
+        });
+        return;
+      }
       setState(() {
         _discoveredAgents = agents;
         _isDiscovering = false;
@@ -605,7 +634,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
     } catch (e) {
       setState(() {
         _isDiscovering = false;
-        _discoveryError = "Could not connect to server. Check URL and token.";
+        _discoveryError = 'Could not connect to server. Check URL and token.';
       });
     }
   }
@@ -795,6 +824,10 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
                           _servers = [..._servers, newServer];
                           _newServer = newServer;
                           _selectedServerId = newServer.id;
+                          // Reset discovery state when server changes
+                          _discoveredAgents = null;
+                          _discoveryError = null;
+                          _selectedAgentName = null;
                         });
                       }
                     } else {
@@ -803,6 +836,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
                         // Reset discovery state when server changes
                         _discoveredAgents = null;
                         _discoveryError = null;
+                        _selectedAgentName = null;
                       });
                     }
                   },

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import '../models/elevenlabs_voice.dart';
 import '../models/settings.dart';
 import '../models/voice_config.dart';
 import '../providers/agent_switcher_provider.dart';
+import '../services/openclaw_service.dart';
 
 const _uuid = Uuid();
 
@@ -543,6 +544,13 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
   final _formKey = GlobalKey<FormState>();
   OpenClawServer? _newServer;
 
+  // OpenClaw agent discovery state
+  final _openClawService = OpenClawService();
+  List<String>? _discoveredAgents;
+  bool _isDiscovering = false;
+  String? _discoveryError;
+  String? _selectedAgentName;
+
   @override
   void initState() {
     super.initState();
@@ -559,6 +567,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
         widget.agent?.voiceId ?? widget.voices.firstOrNull?.id ?? 'system';
     _selectedServerId = widget.agent?.serverId;
     _servers = widget.servers;
+    _selectedAgentName = widget.agent?.agentName;
   }
 
   String _defaultModel() {
@@ -569,6 +578,35 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
         return 'gpt-4o';
       case AgentType.openclaw:
         return '';
+    }
+  }
+
+  Future<void> _discoverAgents() async {
+    final server =
+        widget.servers.firstWhereOrNull((s) => s.id == _selectedServerId);
+    if (server == null) return;
+    setState(() {
+      _isDiscovering = true;
+      _discoveryError = null;
+    });
+    try {
+      final agents = await _openClawService.fetchAgents(server);
+      setState(() {
+        _discoveredAgents = agents;
+        _isDiscovering = false;
+        // Auto-select if current value is in list, else select first
+        if (_selectedAgentName != null && agents.contains(_selectedAgentName)) {
+          // keep current selection
+        } else {
+          _selectedAgentName = agents.first;
+          _agentNameController.text = agents.first;
+        }
+      });
+    } catch (e) {
+      setState(() {
+        _isDiscovering = false;
+        _discoveryError = "Could not connect to server. Check URL and token.";
+      });
     }
   }
 
@@ -589,7 +627,7 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
     final apiKey = _apiKeyController.text.trim();
     final model = _modelController.text.trim();
     final baseUrl = _baseUrlController.text.trim();
-    final agentName = _agentNameController.text.trim();
+    final agentName = _selectedAgentName ?? _agentNameController.text.trim();
 
     AgentConfig result;
     switch (widget.agentType) {
@@ -760,23 +798,82 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
                         });
                       }
                     } else {
-                      setState(() => _selectedServerId = v);
+                      setState(() {
+                        _selectedServerId = v;
+                        // Reset discovery state when server changes
+                        _discoveredAgents = null;
+                        _discoveryError = null;
+                      });
                     }
                   },
                   validator: (v) => v == null ? 'Server is required' : null,
                 ),
                 const SizedBox(height: 12),
-                TextFormField(
-                  controller: _agentNameController,
-                  decoration: const InputDecoration(
-                    labelText: 'Agent Name',
-                    hintText: 'main',
-                    border: OutlineInputBorder(),
+                // Test & Discover button
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton(
+                    onPressed: _selectedServerId == null || _isDiscovering
+                        ? null
+                        : _discoverAgents,
+                    child: _isDiscovering
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Test & Discover Agents'),
                   ),
-                  validator: (v) => (v == null || v.trim().isEmpty)
-                      ? 'Agent name is required'
-                      : null,
                 ),
+                if (_discoveryError != null) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    _discoveryError!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 12),
+                // Agent name input - dropdown if discovered, textfield otherwise
+                if (_discoveredAgents != null)
+                  DropdownButtonFormField<String>(
+                    initialValue: _selectedAgentName,
+                    decoration: const InputDecoration(
+                      labelText: 'Agent Name',
+                      border: OutlineInputBorder(),
+                    ),
+                    items: _discoveredAgents!
+                        .map((name) => DropdownMenuItem(
+                              value: name,
+                              child: Text(name),
+                            ))
+                        .toList(),
+                    onChanged: (v) {
+                      if (v != null) {
+                        setState(() {
+                          _selectedAgentName = v;
+                          _agentNameController.text = v;
+                        });
+                      }
+                    },
+                    validator: (v) => (v == null || v.trim().isEmpty)
+                        ? 'Agent name is required'
+                        : null,
+                  )
+                else
+                  TextFormField(
+                    controller: _agentNameController,
+                    decoration: const InputDecoration(
+                      labelText: 'Agent Name',
+                      hintText: 'main',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (v) => (v == null || v.trim().isEmpty)
+                        ? 'Agent name is required'
+                        : null,
+                  ),
               ],
 
               const SizedBox(height: 12),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -602,6 +602,12 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
     }
   }
 
+  void _resetDiscoveryState() {
+    _discoveredAgents = null;
+    _discoveryError = null;
+    _selectedAgentName = null;
+  }
+
   Future<void> _discoverAgents() async {
     final server =
         widget.servers.firstWhereOrNull((s) => s.id == _selectedServerId);
@@ -624,10 +630,9 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
       setState(() {
         _discoveredAgents = agents;
         _isDiscovering = false;
-        // Auto-select if current value is in list, else select first
-        if (_selectedAgentName != null && agents.contains(_selectedAgentName)) {
-          // keep current selection
-        } else {
+        // Auto-select current value if in list, else select first
+        if (_selectedAgentName == null ||
+            !agents.contains(_selectedAgentName)) {
           _selectedAgentName = agents.first;
           _agentNameController.text = agents.first;
         }
@@ -821,24 +826,17 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
                         builder: (_) => const _ServerFormDialog(),
                       );
                       if (newServer != null && mounted) {
-                        // Track new server to return to parent and add to local list
                         setState(() {
                           _servers = [..._servers, newServer];
                           _newServer = newServer;
                           _selectedServerId = newServer.id;
-                          // Reset discovery state when server changes
-                          _discoveredAgents = null;
-                          _discoveryError = null;
-                          _selectedAgentName = null;
+                          _resetDiscoveryState();
                         });
                       }
                     } else {
                       setState(() {
                         _selectedServerId = v;
-                        // Reset discovery state when server changes
-                        _discoveredAgents = null;
-                        _discoveryError = null;
-                        _selectedAgentName = null;
+                        _resetDiscoveryState();
                       });
                     }
                   },

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -615,34 +615,33 @@ class _AgentFormDialogState extends State<_AgentFormDialog> {
       _isDiscovering = true;
       _discoveryError = null;
     });
+
+    List<String>? agents;
+    String? error;
     try {
-      final agents = await _openClawService.fetchAgents(server);
-      if (!mounted) return;
-      if (agents.isEmpty) {
-        setState(() {
-          _isDiscovering = false;
-          _discoveryError =
-              'No agents found on this server. Check your server configuration.';
-        });
-        return;
+      final result = await _openClawService.fetchAgents(server);
+      if (result.isEmpty) {
+        error =
+            'No agents found on this server. Check your server configuration.';
+      } else {
+        agents = result;
       }
-      setState(() {
-        _discoveredAgents = agents;
-        _isDiscovering = false;
-        // Auto-select current value if in list, else select first
-        if (_selectedAgentName == null ||
-            !agents.contains(_selectedAgentName)) {
-          _selectedAgentName = agents.first;
-          _agentNameController.text = agents.first;
-        }
-      });
     } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _isDiscovering = false;
-        _discoveryError = 'Failed to discover agents: $e';
-      });
+      error = 'Failed to discover agents: $e';
     }
+
+    if (!mounted) return;
+    setState(() {
+      _isDiscovering = false;
+      _discoveryError = error;
+      _discoveredAgents = agents;
+      if (agents != null &&
+          (_selectedAgentName == null ||
+              !agents.contains(_selectedAgentName))) {
+        _selectedAgentName = agents.first;
+        _agentNameController.text = agents.first;
+      }
+    });
   }
 
   @override

--- a/lib/services/openclaw_service.dart
+++ b/lib/services/openclaw_service.dart
@@ -3,6 +3,11 @@ import '../models/agent_config.dart';
 import 'http_client_factory.dart';
 
 class OpenClawService {
+  /// Fetches available agents from an OpenClaw server.
+  ///
+  /// Returns a list of agent name strings (without the `openclaw:` prefix).
+  /// Throws an [Exception] if the server is unreachable, returns a non-200
+  /// status, or the response cannot be parsed.
   Future<List<String>> fetchAgents(OpenClawServer server) async {
     final client = buildHttpClient(
       allowBadCertificate: server.allowBadCertificate,
@@ -20,7 +25,10 @@ class OpenClawService {
           .get(uri, headers: headers)
           .timeout(const Duration(seconds: 5));
 
-      if (response.statusCode != 200) return ['main'];
+      if (response.statusCode != 200) {
+        throw Exception(
+            'Server returned status ${response.statusCode}. Check URL and token.');
+      }
 
       final data = jsonDecode(response.body) as Map<String, dynamic>;
       final models =
@@ -31,7 +39,6 @@ class OpenClawService {
           .map((m) => m['id'] as String? ?? '')
           .where((id) => id.startsWith('openclaw:') || id.startsWith('agent:'))
           .map((id) {
-        // Strip openclaw: or agent: prefix to get just the agent name
         if (id.startsWith('openclaw:')) {
           return id.substring('openclaw:'.length);
         } else if (id.startsWith('agent:')) {
@@ -40,11 +47,7 @@ class OpenClawService {
         return id;
       }).toList();
 
-      return agents.isEmpty ? ['main'] : agents;
-    } catch (e, s) {
-      // ignore: avoid_print
-      print('Failed to fetch OpenClaw agents: $e\n$s');
-      return ['main'];
+      return agents;
     } finally {
       client.close();
     }

--- a/test/unit/providers/agent_switcher_provider_test.mocks.dart
+++ b/test/unit/providers/agent_switcher_provider_test.mocks.dart
@@ -30,8 +30,13 @@ import 'package:voiceapp/services/speech_service.dart' as _i9;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeSettings_0 extends _i1.SmartFake implements _i2.Settings {
-  _FakeSettings_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSettings_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [ConversationProvider].
@@ -67,18 +72,23 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i2.Settings get settings => (super.noSuchMethod(
         Invocation.getter(#settings),
-        returnValue: _FakeSettings_0(this, Invocation.getter(#settings)),
+        returnValue: _FakeSettings_0(
+          this,
+          Invocation.getter(#settings),
+        ),
       ) as _i2.Settings);
 
   @override
-  bool get initialized =>
-      (super.noSuchMethod(Invocation.getter(#initialized), returnValue: false)
-          as bool);
+  bool get initialized => (super.noSuchMethod(
+        Invocation.getter(#initialized),
+        returnValue: false,
+      ) as bool);
 
   @override
-  bool get hasApiKey =>
-      (super.noSuchMethod(Invocation.getter(#hasApiKey), returnValue: false)
-          as bool);
+  bool get hasApiKey => (super.noSuchMethod(
+        Invocation.getter(#hasApiKey),
+        returnValue: false,
+      ) as bool);
 
   @override
   bool get conversationalMode => (super.noSuchMethod(
@@ -87,24 +97,32 @@ class MockConversationProvider extends _i1.Mock
       ) as bool);
 
   @override
-  double get pauseDuration =>
-      (super.noSuchMethod(Invocation.getter(#pauseDuration), returnValue: 0.0)
-          as double);
+  double get pauseDuration => (super.noSuchMethod(
+        Invocation.getter(#pauseDuration),
+        returnValue: 0.0,
+      ) as double);
 
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
 
   @override
   void forceStateForTesting(_i4.ConversationState? state) => super.noSuchMethod(
-        Invocation.method(#forceStateForTesting, [state]),
+        Invocation.method(
+          #forceStateForTesting,
+          [state],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i7.Future<void> initialize() => (super.noSuchMethod(
-        Invocation.method(#initialize, []),
+        Invocation.method(
+          #initialize,
+          [],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
@@ -112,33 +130,48 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i7.Future<void> initializeForAgent(_i2.Settings? agentSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#initializeForAgent, [agentSettings]),
+        Invocation.method(
+          #initializeForAgent,
+          [agentSettings],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
 
   @override
   void toggleConversation() => super.noSuchMethod(
-        Invocation.method(#toggleConversation, []),
+        Invocation.method(
+          #toggleConversation,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void clearMessages() => super.noSuchMethod(
-        Invocation.method(#clearMessages, []),
+        Invocation.method(
+          #clearMessages,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void clearError() => super.noSuchMethod(
-        Invocation.method(#clearError, []),
+        Invocation.method(
+          #clearError,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i7.Future<void> updateSettings(_i2.Settings? newSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#updateSettings, [newSettings]),
+        Invocation.method(
+          #updateSettings,
+          [newSettings],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
@@ -146,32 +179,47 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i7.Future<void> applyAgentSettings(_i2.Settings? agentSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#applyAgentSettings, [agentSettings]),
+        Invocation.method(
+          #applyAgentSettings,
+          [agentSettings],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(#dispose, []),
+        Invocation.method(
+          #dispose,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void addListener(_i8.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#addListener, [listener]),
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void removeListener(_i8.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#removeListener, [listener]),
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void notifyListeners() => super.noSuchMethod(
-        Invocation.method(#notifyListeners, []),
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }
@@ -185,14 +233,16 @@ class MockSpeechService extends _i1.Mock implements _i9.SpeechService {
   }
 
   @override
-  bool get isAvailable =>
-      (super.noSuchMethod(Invocation.getter(#isAvailable), returnValue: false)
-          as bool);
+  bool get isAvailable => (super.noSuchMethod(
+        Invocation.getter(#isAvailable),
+        returnValue: false,
+      ) as bool);
 
   @override
-  bool get isListening =>
-      (super.noSuchMethod(Invocation.getter(#isListening), returnValue: false)
-          as bool);
+  bool get isListening => (super.noSuchMethod(
+        Invocation.getter(#isListening),
+        returnValue: false,
+      ) as bool);
 
   @override
   bool get hasReportedStopForTesting => (super.noSuchMethod(
@@ -202,63 +252,88 @@ class MockSpeechService extends _i1.Mock implements _i9.SpeechService {
 
   @override
   set onFinalResult(dynamic Function(String)? value) => super.noSuchMethod(
-        Invocation.setter(#onFinalResult, value),
+        Invocation.setter(
+          #onFinalResult,
+          value,
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   set onPartialResult(dynamic Function(String)? value) => super.noSuchMethod(
-        Invocation.setter(#onPartialResult, value),
+        Invocation.setter(
+          #onPartialResult,
+          value,
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   set onStopped(dynamic Function()? value) => super.noSuchMethod(
-        Invocation.setter(#onStopped, value),
+        Invocation.setter(
+          #onStopped,
+          value,
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void triggerStatusForTesting(String? status) => super.noSuchMethod(
-        Invocation.method(#triggerStatusForTesting, [status]),
+        Invocation.method(
+          #triggerStatusForTesting,
+          [status],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i7.Future<bool> initialize() => (super.noSuchMethod(
-        Invocation.method(#initialize, []),
+        Invocation.method(
+          #initialize,
+          [],
+        ),
         returnValue: _i7.Future<bool>.value(false),
       ) as _i7.Future<bool>);
 
   @override
-  _i7.Future<void> startListening({
-    Duration? pauseDuration = const Duration(seconds: 4),
-  }) =>
+  _i7.Future<void> startListening(
+          {Duration? pauseDuration = const Duration(seconds: 4)}) =>
       (super.noSuchMethod(
-        Invocation.method(#startListening, [], {
-          #pauseDuration: pauseDuration,
-        }),
+        Invocation.method(
+          #startListening,
+          [],
+          {#pauseDuration: pauseDuration},
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
 
   @override
   _i7.Future<void> stopListening() => (super.noSuchMethod(
-        Invocation.method(#stopListening, []),
+        Invocation.method(
+          #stopListening,
+          [],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
 
   @override
   _i7.Future<void> cancelListening() => (super.noSuchMethod(
-        Invocation.method(#cancelListening, []),
+        Invocation.method(
+          #cancelListening,
+          [],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(#dispose, []),
+        Invocation.method(
+          #dispose,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }

--- a/test/unit/providers/conversation_provider_test.mocks.dart
+++ b/test/unit/providers/conversation_provider_test.mocks.dart
@@ -27,8 +27,13 @@ import 'package:voiceapp/services/tts_service.dart' as _i6;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeSettings_0 extends _i1.SmartFake implements _i2.Settings {
-  _FakeSettings_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSettings_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [SpeechService].
@@ -40,14 +45,16 @@ class MockSpeechService extends _i1.Mock implements _i3.SpeechService {
   }
 
   @override
-  bool get isAvailable =>
-      (super.noSuchMethod(Invocation.getter(#isAvailable), returnValue: false)
-          as bool);
+  bool get isAvailable => (super.noSuchMethod(
+        Invocation.getter(#isAvailable),
+        returnValue: false,
+      ) as bool);
 
   @override
-  bool get isListening =>
-      (super.noSuchMethod(Invocation.getter(#isListening), returnValue: false)
-          as bool);
+  bool get isListening => (super.noSuchMethod(
+        Invocation.getter(#isListening),
+        returnValue: false,
+      ) as bool);
 
   @override
   bool get hasReportedStopForTesting => (super.noSuchMethod(
@@ -57,63 +64,88 @@ class MockSpeechService extends _i1.Mock implements _i3.SpeechService {
 
   @override
   set onFinalResult(dynamic Function(String)? value) => super.noSuchMethod(
-        Invocation.setter(#onFinalResult, value),
+        Invocation.setter(
+          #onFinalResult,
+          value,
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   set onPartialResult(dynamic Function(String)? value) => super.noSuchMethod(
-        Invocation.setter(#onPartialResult, value),
+        Invocation.setter(
+          #onPartialResult,
+          value,
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   set onStopped(dynamic Function()? value) => super.noSuchMethod(
-        Invocation.setter(#onStopped, value),
+        Invocation.setter(
+          #onStopped,
+          value,
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void triggerStatusForTesting(String? status) => super.noSuchMethod(
-        Invocation.method(#triggerStatusForTesting, [status]),
+        Invocation.method(
+          #triggerStatusForTesting,
+          [status],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i4.Future<bool> initialize() => (super.noSuchMethod(
-        Invocation.method(#initialize, []),
+        Invocation.method(
+          #initialize,
+          [],
+        ),
         returnValue: _i4.Future<bool>.value(false),
       ) as _i4.Future<bool>);
 
   @override
-  _i4.Future<void> startListening({
-    Duration? pauseDuration = const Duration(seconds: 4),
-  }) =>
+  _i4.Future<void> startListening(
+          {Duration? pauseDuration = const Duration(seconds: 4)}) =>
       (super.noSuchMethod(
-        Invocation.method(#startListening, [], {
-          #pauseDuration: pauseDuration,
-        }),
+        Invocation.method(
+          #startListening,
+          [],
+          {#pauseDuration: pauseDuration},
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
 
   @override
   _i4.Future<void> stopListening() => (super.noSuchMethod(
-        Invocation.method(#stopListening, []),
+        Invocation.method(
+          #stopListening,
+          [],
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
 
   @override
   _i4.Future<void> cancelListening() => (super.noSuchMethod(
-        Invocation.method(#cancelListening, []),
+        Invocation.method(
+          #cancelListening,
+          [],
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(#dispose, []),
+        Invocation.method(
+          #dispose,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }
@@ -127,16 +159,35 @@ class MockSettingsService extends _i1.Mock implements _i5.SettingsService {
   }
 
   @override
-  _i4.Future<_i2.Settings> load() => (super.noSuchMethod(
-        Invocation.method(#load, []),
-        returnValue: _i4.Future<_i2.Settings>.value(
-          _FakeSettings_0(this, Invocation.method(#load, [])),
+  set lastLoadedConfigCount(int? value) => super.noSuchMethod(
+        Invocation.setter(
+          #lastLoadedConfigCount,
+          value,
         ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i4.Future<_i2.Settings> load() => (super.noSuchMethod(
+        Invocation.method(
+          #load,
+          [],
+        ),
+        returnValue: _i4.Future<_i2.Settings>.value(_FakeSettings_0(
+          this,
+          Invocation.method(
+            #load,
+            [],
+          ),
+        )),
       ) as _i4.Future<_i2.Settings>);
 
   @override
   _i4.Future<void> save(_i2.Settings? settings) => (super.noSuchMethod(
-        Invocation.method(#save, [settings]),
+        Invocation.method(
+          #save,
+          [settings],
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
@@ -152,60 +203,101 @@ class MockTtsService extends _i1.Mock implements _i6.TtsService {
 
   @override
   set onDone(dynamic Function()? value) => super.noSuchMethod(
-        Invocation.setter(#onDone, value),
+        Invocation.setter(
+          #onDone,
+          value,
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
-  _i4.Future<void> initialize({double? rate = 0.5, double? pitch = 1.0}) =>
+  _i4.Future<void> initialize({
+    double? rate = 0.5,
+    double? pitch = 1.0,
+  }) =>
       (super.noSuchMethod(
-        Invocation.method(#initialize, [], {#rate: rate, #pitch: pitch}),
+        Invocation.method(
+          #initialize,
+          [],
+          {
+            #rate: rate,
+            #pitch: pitch,
+          },
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
 
   @override
-  void updateSettings(double? rate, double? pitch) => super.noSuchMethod(
-        Invocation.method(#updateSettings, [rate, pitch]),
+  void updateSettings(
+    double? rate,
+    double? pitch,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #updateSettings,
+          [
+            rate,
+            pitch,
+          ],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void enqueue(String? text) => super.noSuchMethod(
-        Invocation.method(#enqueue, [text]),
+        Invocation.method(
+          #enqueue,
+          [text],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void markFinished() => super.noSuchMethod(
-        Invocation.method(#markFinished, []),
+        Invocation.method(
+          #markFinished,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i4.Future<void> waitUntilDone() => (super.noSuchMethod(
-        Invocation.method(#waitUntilDone, []),
+        Invocation.method(
+          #waitUntilDone,
+          [],
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
 
   @override
   _i4.Future<void> stop() => (super.noSuchMethod(
-        Invocation.method(#stop, []),
+        Invocation.method(
+          #stop,
+          [],
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
 
   @override
   _i4.Future<void> reset() => (super.noSuchMethod(
-        Invocation.method(#reset, []),
+        Invocation.method(
+          #reset,
+          [],
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
 
   @override
   _i4.Future<void> dispose() => (super.noSuchMethod(
-        Invocation.method(#dispose, []),
+        Invocation.method(
+          #dispose,
+          [],
+        ),
         returnValue: _i4.Future<void>.value(),
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);

--- a/test/widget/agent_switcher_screen_test.mocks.dart
+++ b/test/widget/agent_switcher_screen_test.mocks.dart
@@ -31,14 +31,24 @@ import 'package:voiceapp/providers/conversation_provider.dart' as _i3;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeSettings_0 extends _i1.SmartFake implements _i2.Settings {
-  _FakeSettings_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSettings_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeConversationProvider_1 extends _i1.SmartFake
     implements _i3.ConversationProvider {
-  _FakeConversationProvider_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeConversationProvider_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [AgentSwitcherProvider].
@@ -57,39 +67,54 @@ class MockAgentSwitcherProvider extends _i1.Mock
       ) as List<_i5.AgentConfig>);
 
   @override
-  int get currentIndex =>
-      (super.noSuchMethod(Invocation.getter(#currentIndex), returnValue: 0)
-          as int);
+  int get currentIndex => (super.noSuchMethod(
+        Invocation.getter(#currentIndex),
+        returnValue: 0,
+      ) as int);
 
   @override
   _i2.Settings get settings => (super.noSuchMethod(
         Invocation.getter(#settings),
-        returnValue: _FakeSettings_0(this, Invocation.getter(#settings)),
+        returnValue: _FakeSettings_0(
+          this,
+          Invocation.getter(#settings),
+        ),
       ) as _i2.Settings);
 
   @override
-  bool get initialized =>
-      (super.noSuchMethod(Invocation.getter(#initialized), returnValue: false)
-          as bool);
+  bool get initialized => (super.noSuchMethod(
+        Invocation.getter(#initialized),
+        returnValue: false,
+      ) as bool);
 
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
 
   @override
   _i3.ConversationProvider providerFor(_i5.AgentConfig? agent) =>
       (super.noSuchMethod(
-        Invocation.method(#providerFor, [agent]),
+        Invocation.method(
+          #providerFor,
+          [agent],
+        ),
         returnValue: _FakeConversationProvider_1(
           this,
-          Invocation.method(#providerFor, [agent]),
+          Invocation.method(
+            #providerFor,
+            [agent],
+          ),
         ),
       ) as _i3.ConversationProvider);
 
   @override
   _i6.Future<void> initialize() => (super.noSuchMethod(
-        Invocation.method(#initialize, []),
+        Invocation.method(
+          #initialize,
+          [],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
@@ -97,39 +122,57 @@ class MockAgentSwitcherProvider extends _i1.Mock
   @override
   _i6.Future<void> updateSettings(_i2.Settings? newSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#updateSettings, [newSettings]),
+        Invocation.method(
+          #updateSettings,
+          [newSettings],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
 
   @override
   _i6.Future<void> setCurrentIndex(int? index) => (super.noSuchMethod(
-        Invocation.method(#setCurrentIndex, [index]),
+        Invocation.method(
+          #setCurrentIndex,
+          [index],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(#dispose, []),
+        Invocation.method(
+          #dispose,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#addListener, [listener]),
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#removeListener, [listener]),
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void notifyListeners() => super.noSuchMethod(
-        Invocation.method(#notifyListeners, []),
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }
@@ -167,18 +210,23 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i2.Settings get settings => (super.noSuchMethod(
         Invocation.getter(#settings),
-        returnValue: _FakeSettings_0(this, Invocation.getter(#settings)),
+        returnValue: _FakeSettings_0(
+          this,
+          Invocation.getter(#settings),
+        ),
       ) as _i2.Settings);
 
   @override
-  bool get initialized =>
-      (super.noSuchMethod(Invocation.getter(#initialized), returnValue: false)
-          as bool);
+  bool get initialized => (super.noSuchMethod(
+        Invocation.getter(#initialized),
+        returnValue: false,
+      ) as bool);
 
   @override
-  bool get hasApiKey =>
-      (super.noSuchMethod(Invocation.getter(#hasApiKey), returnValue: false)
-          as bool);
+  bool get hasApiKey => (super.noSuchMethod(
+        Invocation.getter(#hasApiKey),
+        returnValue: false,
+      ) as bool);
 
   @override
   bool get conversationalMode => (super.noSuchMethod(
@@ -187,24 +235,32 @@ class MockConversationProvider extends _i1.Mock
       ) as bool);
 
   @override
-  double get pauseDuration =>
-      (super.noSuchMethod(Invocation.getter(#pauseDuration), returnValue: 0.0)
-          as double);
+  double get pauseDuration => (super.noSuchMethod(
+        Invocation.getter(#pauseDuration),
+        returnValue: 0.0,
+      ) as double);
 
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
 
   @override
   void forceStateForTesting(_i8.ConversationState? state) => super.noSuchMethod(
-        Invocation.method(#forceStateForTesting, [state]),
+        Invocation.method(
+          #forceStateForTesting,
+          [state],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i6.Future<void> initialize() => (super.noSuchMethod(
-        Invocation.method(#initialize, []),
+        Invocation.method(
+          #initialize,
+          [],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
@@ -212,33 +268,48 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i6.Future<void> initializeForAgent(_i2.Settings? agentSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#initializeForAgent, [agentSettings]),
+        Invocation.method(
+          #initializeForAgent,
+          [agentSettings],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
 
   @override
   void toggleConversation() => super.noSuchMethod(
-        Invocation.method(#toggleConversation, []),
+        Invocation.method(
+          #toggleConversation,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void clearMessages() => super.noSuchMethod(
-        Invocation.method(#clearMessages, []),
+        Invocation.method(
+          #clearMessages,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void clearError() => super.noSuchMethod(
-        Invocation.method(#clearError, []),
+        Invocation.method(
+          #clearError,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i6.Future<void> updateSettings(_i2.Settings? newSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#updateSettings, [newSettings]),
+        Invocation.method(
+          #updateSettings,
+          [newSettings],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
@@ -246,32 +317,47 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i6.Future<void> applyAgentSettings(_i2.Settings? agentSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#applyAgentSettings, [agentSettings]),
+        Invocation.method(
+          #applyAgentSettings,
+          [agentSettings],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(#dispose, []),
+        Invocation.method(
+          #dispose,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#addListener, [listener]),
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#removeListener, [listener]),
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void notifyListeners() => super.noSuchMethod(
-        Invocation.method(#notifyListeners, []),
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }

--- a/test/widget/home_screen_test.mocks.dart
+++ b/test/widget/home_screen_test.mocks.dart
@@ -29,8 +29,13 @@ import 'package:voiceapp/providers/conversation_provider.dart' as _i3;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeSettings_0 extends _i1.SmartFake implements _i2.Settings {
-  _FakeSettings_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSettings_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [ConversationProvider].
@@ -66,18 +71,23 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i2.Settings get settings => (super.noSuchMethod(
         Invocation.getter(#settings),
-        returnValue: _FakeSettings_0(this, Invocation.getter(#settings)),
+        returnValue: _FakeSettings_0(
+          this,
+          Invocation.getter(#settings),
+        ),
       ) as _i2.Settings);
 
   @override
-  bool get initialized =>
-      (super.noSuchMethod(Invocation.getter(#initialized), returnValue: false)
-          as bool);
+  bool get initialized => (super.noSuchMethod(
+        Invocation.getter(#initialized),
+        returnValue: false,
+      ) as bool);
 
   @override
-  bool get hasApiKey =>
-      (super.noSuchMethod(Invocation.getter(#hasApiKey), returnValue: false)
-          as bool);
+  bool get hasApiKey => (super.noSuchMethod(
+        Invocation.getter(#hasApiKey),
+        returnValue: false,
+      ) as bool);
 
   @override
   bool get conversationalMode => (super.noSuchMethod(
@@ -86,24 +96,32 @@ class MockConversationProvider extends _i1.Mock
       ) as bool);
 
   @override
-  double get pauseDuration =>
-      (super.noSuchMethod(Invocation.getter(#pauseDuration), returnValue: 0.0)
-          as double);
+  double get pauseDuration => (super.noSuchMethod(
+        Invocation.getter(#pauseDuration),
+        returnValue: 0.0,
+      ) as double);
 
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
 
   @override
   void forceStateForTesting(_i4.ConversationState? state) => super.noSuchMethod(
-        Invocation.method(#forceStateForTesting, [state]),
+        Invocation.method(
+          #forceStateForTesting,
+          [state],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i7.Future<void> initialize() => (super.noSuchMethod(
-        Invocation.method(#initialize, []),
+        Invocation.method(
+          #initialize,
+          [],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
@@ -111,33 +129,48 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i7.Future<void> initializeForAgent(_i2.Settings? agentSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#initializeForAgent, [agentSettings]),
+        Invocation.method(
+          #initializeForAgent,
+          [agentSettings],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
 
   @override
   void toggleConversation() => super.noSuchMethod(
-        Invocation.method(#toggleConversation, []),
+        Invocation.method(
+          #toggleConversation,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void clearMessages() => super.noSuchMethod(
-        Invocation.method(#clearMessages, []),
+        Invocation.method(
+          #clearMessages,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void clearError() => super.noSuchMethod(
-        Invocation.method(#clearError, []),
+        Invocation.method(
+          #clearError,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   _i7.Future<void> updateSettings(_i2.Settings? newSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#updateSettings, [newSettings]),
+        Invocation.method(
+          #updateSettings,
+          [newSettings],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
@@ -145,32 +178,47 @@ class MockConversationProvider extends _i1.Mock
   @override
   _i7.Future<void> applyAgentSettings(_i2.Settings? agentSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#applyAgentSettings, [agentSettings]),
+        Invocation.method(
+          #applyAgentSettings,
+          [agentSettings],
+        ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(#dispose, []),
+        Invocation.method(
+          #dispose,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void addListener(_i8.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#addListener, [listener]),
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void removeListener(_i8.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#removeListener, [listener]),
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void notifyListeners() => super.noSuchMethod(
-        Invocation.method(#notifyListeners, []),
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 }

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -8,8 +8,9 @@ import 'package:voiceapp/models/settings.dart';
 import 'package:voiceapp/models/voice_config.dart';
 import 'package:voiceapp/providers/agent_switcher_provider.dart';
 import 'package:voiceapp/screens/settings_screen.dart';
+import 'package:voiceapp/services/openclaw_service.dart';
 
-@GenerateMocks([AgentSwitcherProvider])
+@GenerateMocks([AgentSwitcherProvider, OpenClawService])
 import 'settings_screen_test.mocks.dart';
 
 void main() {
@@ -497,6 +498,75 @@ void main() {
 
       // Should show TextFormField for agent name before discovery
       expect(find.widgetWithText(TextFormField, 'Agent Name'), findsOneWidget);
+    });
+
+    testWidgets('shows dropdown after successful agent discovery',
+        (tester) async {
+      final server = OpenClawServer(
+        id: 'test-id',
+        name: 'Test Server',
+        baseUrl: 'http://localhost:3000/v1',
+      );
+      final voice = VoiceConfig.system();
+
+      // Create a mock OpenClawService
+      final mockOpenClawService = MockOpenClawService();
+      when(mockOpenClawService.fetchAgents(any))
+          .thenAnswer((_) async => ['main', 'elysse', 'clive']);
+
+      // Create the dialog widget with mock service
+      final dialogWidget = MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              // Show the dialog on first frame
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                showDialog(
+                  context: context,
+                  builder: (_) => SettingsScreen.buildAgentFormDialogForTesting(
+                    agentType: AgentType.openclaw,
+                    voices: [voice],
+                    servers: [server],
+                    openClawService: mockOpenClawService,
+                  ),
+                );
+              });
+              return Container();
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(dialogWidget);
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Select the server from the dropdown
+      await tester
+          .tap(find.widgetWithText(DropdownButtonFormField<String>, 'Server'));
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Tap the server name in the dropdown menu
+      await tester.tap(find.text('Test Server').last);
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // TextFormField should be shown initially
+      expect(find.widgetWithText(TextFormField, 'Agent Name'), findsOneWidget);
+
+      // Tap the Test & Discover button
+      await tester.tap(find.text('Test & Discover Agents'));
+      // Wait for the async operation to complete
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Should now show a dropdown with discovered agents instead of textfield
+      expect(find.widgetWithText(DropdownButtonFormField<String>, 'Agent Name'),
+          findsOneWidget);
+
+      // Verify the mock was called
+      verify(mockOpenClawService.fetchAgents(server)).called(1);
     });
   });
 }

--- a/test/widget/settings_screen_test.dart
+++ b/test/widget/settings_screen_test.dart
@@ -414,4 +414,89 @@ void main() {
       expect(find.text('Server 2'), findsOneWidget);
     });
   });
+
+  group('SettingsScreen OpenClaw Agent Discovery', () {
+    testWidgets('shows Test & Discover button in openclaw agent dialog', (
+      tester,
+    ) async {
+      final server = OpenClawServer(
+        id: 'test-id',
+        name: 'Test Server',
+        baseUrl: 'http://localhost:3000/v1',
+      );
+      final voice = VoiceConfig.system();
+      when(
+        mockProvider.settings,
+      ).thenReturn(Settings(openclawServers: [server], voices: [voice]));
+
+      await pumpSettings(tester);
+
+      // Open Add Agent dialog
+      await tester.tap(find.text('Add Agent'));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Select OpenClaw
+      await tester.tap(find.text('OpenClaw'));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Should show Test & Discover button
+      expect(find.text('Test & Discover Agents'), findsOneWidget);
+      expect(find.widgetWithText(OutlinedButton, 'Test & Discover Agents'),
+          findsOneWidget);
+    });
+
+    testWidgets('Test & Discover button is disabled when no server selected',
+        (tester) async {
+      final voice = VoiceConfig.system();
+      when(
+        mockProvider.settings,
+      ).thenReturn(Settings(voices: [voice]));
+
+      await pumpSettings(tester);
+
+      // Open Add Agent dialog
+      await tester.tap(find.text('Add Agent'));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Select OpenClaw
+      await tester.tap(find.text('OpenClaw'));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Button should be disabled (no server in dropdown)
+      final button = tester.widget<OutlinedButton>(
+          find.widgetWithText(OutlinedButton, 'Test & Discover Agents'));
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('shows agent name TextFormField initially', (tester) async {
+      final server = OpenClawServer(
+        id: 'test-id',
+        name: 'Test Server',
+        baseUrl: 'http://localhost:3000/v1',
+      );
+      final voice = VoiceConfig.system();
+      when(
+        mockProvider.settings,
+      ).thenReturn(Settings(openclawServers: [server], voices: [voice]));
+
+      await pumpSettings(tester);
+
+      // Open Add Agent dialog
+      await tester.tap(find.text('Add Agent'));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Select OpenClaw
+      await tester.tap(find.text('OpenClaw'));
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // Should show TextFormField for agent name before discovery
+      expect(find.widgetWithText(TextFormField, 'Agent Name'), findsOneWidget);
+    });
+  });
 }

--- a/test/widget/settings_screen_test.mocks.dart
+++ b/test/widget/settings_screen_test.mocks.dart
@@ -11,6 +11,7 @@ import 'package:voiceapp/models/agent_config.dart' as _i5;
 import 'package:voiceapp/models/settings.dart' as _i2;
 import 'package:voiceapp/providers/agent_switcher_provider.dart' as _i4;
 import 'package:voiceapp/providers/conversation_provider.dart' as _i3;
+import 'package:voiceapp/services/openclaw_service.dart' as _i8;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -28,14 +29,24 @@ import 'package:voiceapp/providers/conversation_provider.dart' as _i3;
 // ignore_for_file: invalid_use_of_internal_member
 
 class _FakeSettings_0 extends _i1.SmartFake implements _i2.Settings {
-  _FakeSettings_0(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeSettings_0(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 class _FakeConversationProvider_1 extends _i1.SmartFake
     implements _i3.ConversationProvider {
-  _FakeConversationProvider_1(Object parent, Invocation parentInvocation)
-      : super(parent, parentInvocation);
+  _FakeConversationProvider_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
 }
 
 /// A class which mocks [AgentSwitcherProvider].
@@ -54,39 +65,54 @@ class MockAgentSwitcherProvider extends _i1.Mock
       ) as List<_i5.AgentConfig>);
 
   @override
-  int get currentIndex =>
-      (super.noSuchMethod(Invocation.getter(#currentIndex), returnValue: 0)
-          as int);
+  int get currentIndex => (super.noSuchMethod(
+        Invocation.getter(#currentIndex),
+        returnValue: 0,
+      ) as int);
 
   @override
   _i2.Settings get settings => (super.noSuchMethod(
         Invocation.getter(#settings),
-        returnValue: _FakeSettings_0(this, Invocation.getter(#settings)),
+        returnValue: _FakeSettings_0(
+          this,
+          Invocation.getter(#settings),
+        ),
       ) as _i2.Settings);
 
   @override
-  bool get initialized =>
-      (super.noSuchMethod(Invocation.getter(#initialized), returnValue: false)
-          as bool);
+  bool get initialized => (super.noSuchMethod(
+        Invocation.getter(#initialized),
+        returnValue: false,
+      ) as bool);
 
   @override
-  bool get hasListeners =>
-      (super.noSuchMethod(Invocation.getter(#hasListeners), returnValue: false)
-          as bool);
+  bool get hasListeners => (super.noSuchMethod(
+        Invocation.getter(#hasListeners),
+        returnValue: false,
+      ) as bool);
 
   @override
   _i3.ConversationProvider providerFor(_i5.AgentConfig? agent) =>
       (super.noSuchMethod(
-        Invocation.method(#providerFor, [agent]),
+        Invocation.method(
+          #providerFor,
+          [agent],
+        ),
         returnValue: _FakeConversationProvider_1(
           this,
-          Invocation.method(#providerFor, [agent]),
+          Invocation.method(
+            #providerFor,
+            [agent],
+          ),
         ),
       ) as _i3.ConversationProvider);
 
   @override
   _i6.Future<void> initialize() => (super.noSuchMethod(
-        Invocation.method(#initialize, []),
+        Invocation.method(
+          #initialize,
+          [],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
@@ -94,39 +120,76 @@ class MockAgentSwitcherProvider extends _i1.Mock
   @override
   _i6.Future<void> updateSettings(_i2.Settings? newSettings) =>
       (super.noSuchMethod(
-        Invocation.method(#updateSettings, [newSettings]),
+        Invocation.method(
+          #updateSettings,
+          [newSettings],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
 
   @override
   _i6.Future<void> setCurrentIndex(int? index) => (super.noSuchMethod(
-        Invocation.method(#setCurrentIndex, [index]),
+        Invocation.method(
+          #setCurrentIndex,
+          [index],
+        ),
         returnValue: _i6.Future<void>.value(),
         returnValueForMissingStub: _i6.Future<void>.value(),
       ) as _i6.Future<void>);
 
   @override
   void dispose() => super.noSuchMethod(
-        Invocation.method(#dispose, []),
+        Invocation.method(
+          #dispose,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void addListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#addListener, [listener]),
+        Invocation.method(
+          #addListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void removeListener(_i7.VoidCallback? listener) => super.noSuchMethod(
-        Invocation.method(#removeListener, [listener]),
+        Invocation.method(
+          #removeListener,
+          [listener],
+        ),
         returnValueForMissingStub: null,
       );
 
   @override
   void notifyListeners() => super.noSuchMethod(
-        Invocation.method(#notifyListeners, []),
+        Invocation.method(
+          #notifyListeners,
+          [],
+        ),
         returnValueForMissingStub: null,
       );
+}
+
+/// A class which mocks [OpenClawService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockOpenClawService extends _i1.Mock implements _i8.OpenClawService {
+  MockOpenClawService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i6.Future<List<String>> fetchAgents(_i5.OpenClawServer? server) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #fetchAgents,
+          [server],
+        ),
+        returnValue: _i6.Future<List<String>>.value(<String>[]),
+      ) as _i6.Future<List<String>>);
 }


### PR DESCRIPTION
Closes #46

## Summary
Re-added the OpenClaw 'Test & Discover Agents' feature that was lost during the settings screen refactor in PR #45.

## Changes
- Added `_discoverAgents()` method in `_AgentFormDialogState` calling `OpenClawService.fetchAgents()`
- 'Test & Discover Agents' button below server dropdown (disabled when no server selected, spinner while discovering)
- On success: DropdownButtonFormField populated with discovered agents
- On failure: inline error message
- Falls back to manual TextFormField if discovery not yet run
- `_save()` uses `_selectedAgentName ?? _agentNameController.text.trim()`

## Tests
- 3 new widget tests: button present, button disabled when no server, text field shown before discovery

## Verification
- flutter analyze --fatal-infos: zero issues
- flutter test: 228 tests passing
- dart format: clean